### PR TITLE
feat: `error.response`. Deprecates `error.headers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ const error = new RequestError("Oops", 500, {
 
 error.message; // Oops
 error.status; // 500
-error.headers; // { 'x-github-request-id': '1:2:3:4' }
 error.request.method; // POST
 error.request.url; // https://api.github.com/foo
 error.request.body; // { bar: 'baz' }
 error.request.headers; // { authorization: 'token [REDACTED]' }
+error.response; // { url, status, headers, data }
 ```
 
 ## LICENSE

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,16 @@
-import { RequestOptions, ResponseHeaders } from "@octokit/types";
+import {
+  RequestOptions,
+  ResponseHeaders,
+  OctokitResponse,
+} from "@octokit/types";
 
-export type RequestErrorOptions = {
-  headers?: ResponseHeaders;
-  request: RequestOptions;
-};
+export type RequestErrorOptions =
+  | {
+      /** @deprecated set `response` instead */
+      headers?: ResponseHeaders;
+      request: RequestOptions;
+    }
+  | {
+      response: OctokitResponse<unknown>;
+      request: RequestOptions;
+    };

--- a/test/request-error.test.ts
+++ b/test/request-error.test.ts
@@ -10,27 +10,27 @@ const mockOptions: RequestErrorOptions = {
 };
 
 describe("RequestError", () => {
-  it("inherits from Error", () => {
+  test("inherits from Error", () => {
     const error = new RequestError("test", 123, mockOptions);
     expect(error).toBeInstanceOf(Error);
   });
 
-  it("sets .name to 'RequestError'", () => {
+  test("sets .name to 'RequestError'", () => {
     const error = new RequestError("test", 123, mockOptions);
     expect(error.name).toBe("HttpError");
   });
 
-  it("sets .message", () => {
+  test("sets .message", () => {
     expect(new RequestError("test", 123, mockOptions).message).toEqual("test");
     expect(new RequestError("foo", 123, mockOptions).message).toEqual("foo");
   });
 
-  it("sets .status", () => {
+  test("sets .status", () => {
     expect(new RequestError("test", 123, mockOptions).status).toEqual(123);
     expect(new RequestError("test", 404, mockOptions).status).toEqual(404);
   });
 
-  it("sets .headers", () => {
+  test("sets .headers", () => {
     const options = Object.assign({}, mockOptions, {
       headers: {
         foo: "bar",
@@ -41,7 +41,7 @@ describe("RequestError", () => {
     });
   });
 
-  it("sets .request", () => {
+  test("sets .request", () => {
     const options = Object.assign({}, mockOptions, {
       request: {
         method: "POST",
@@ -67,7 +67,7 @@ describe("RequestError", () => {
     });
   });
 
-  it("redacts credentials from error.request.url", () => {
+  test("redacts credentials from error.request.url", () => {
     const options = Object.assign({}, mockOptions, {
       request: {
         method: "GET",
@@ -83,7 +83,7 @@ describe("RequestError", () => {
     );
   });
 
-  it("redacts client_secret from error.request.url", () => {
+  test("redacts client_secret from error.request.url", () => {
     const options = Object.assign({}, mockOptions, {
       request: {
         method: "GET",
@@ -99,7 +99,7 @@ describe("RequestError", () => {
     );
   });
 
-  it("redacts access_token from error.request.url", () => {
+  test("redacts access_token from error.request.url", () => {
     const options = Object.assign({}, mockOptions, {
       request: {
         method: "GET",
@@ -115,7 +115,7 @@ describe("RequestError", () => {
     );
   });
 
-  it("deprecates .code", () => {
+  test("deprecates .code", () => {
     global.console.warn = jest.fn();
     expect(new RequestError("test", 123, mockOptions).code).toEqual(123);
     expect(new RequestError("test", 404, mockOptions).code).toEqual(404);

--- a/test/request-error.test.ts
+++ b/test/request-error.test.ts
@@ -30,17 +30,6 @@ describe("RequestError", () => {
     expect(new RequestError("test", 404, mockOptions).status).toEqual(404);
   });
 
-  test("sets .headers", () => {
-    const options = Object.assign({}, mockOptions, {
-      headers: {
-        foo: "bar",
-      },
-    });
-    expect(new RequestError("test", 123, options).headers).toEqual({
-      foo: "bar",
-    });
-  });
-
   test("sets .request", () => {
     const options = Object.assign({}, mockOptions, {
       request: {
@@ -115,10 +104,53 @@ describe("RequestError", () => {
     );
   });
 
+  test("error.response", () => {
+    const error = new RequestError("test", 123, {
+      request: mockOptions.request,
+      response: {
+        url: mockOptions.request.url,
+        status: 404,
+        data: {
+          error: "Not Found",
+        },
+        headers: {
+          "x-github-request-id": "1",
+        },
+      },
+    });
+
+    expect(error.response).toStrictEqual({
+      data: {
+        error: "Not Found",
+      },
+      headers: {
+        "x-github-request-id": "1",
+      },
+      status: 404,
+      url: "https://api.github.com/",
+    });
+  });
+
   test("deprecates .code", () => {
     global.console.warn = jest.fn();
     expect(new RequestError("test", 123, mockOptions).code).toEqual(123);
     expect(new RequestError("test", 404, mockOptions).code).toEqual(404);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("deprecates .headers", () => {
+    global.console.warn = jest.fn();
+    expect(new RequestError("test", 123, mockOptions).headers).toStrictEqual(
+      {}
+    );
+    expect(
+      new RequestError("test", 404, { ...mockOptions, headers: { foo: "bar" } })
+        .headers
+    ).toStrictEqual({ foo: "bar" });
+    expect(
+      new RequestError("test", 404, { ...mockOptions, headers: undefined })
+        .headers
+    ).toStrictEqual({});
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
fixes #169