### PR TITLE
ci: stop testing against NodeJS v14, v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 14
-          - 16
           - 18
+          - 20
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       [
         "@pika/plugin-build-node",
         {
-          "minNodeVersion": "14"
+          "minNodeVersion": 18
         }
       ],
       [
@@ -91,6 +91,6 @@
     ]
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v14, v16