### PR TITLE
docs(README): remove self-referencing comment from Octokit usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ try {
   // Octokit errors always have a `error.status` property which is the http response code
   if (error.status) {
     // handle Octokit error
-    // see https://github.com/octokit/request-error.js
   } else {
     // handle all other errors
     throw error;

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ error.request; // { method, url, headers, body }
 error.response; // { url, status, headers, data }
 ```
 
-### Handling
+### Usage with Octokit
 
 ```js
 try {


### PR DESCRIPTION
Follow up to #334

----

## Behavior

n/a

### Other information

docs change only

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [n] No

If `Yes`, what's the impact:

* N/A