### PR TITLE
feat: v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "once": "^1.4.0"
       },
       "devDependencies": {
-        "@octokit/tsconfig": "^2.0.0",
+        "@octokit/tsconfig": "^3.0.0",
         "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",
         "@types/once": "^1.4.0",
@@ -1490,9 +1490,9 @@
       "integrity": "sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw=="
     },
     "node_modules/@octokit/tsconfig": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-3.0.0.tgz",
+      "integrity": "sha512-tQLwgXYfBq9iUbOq26kWCzsJL6DY7qjOLzqcg5tCFQ4ob48H47iX98NudHW7S5OQ/fpSKYJhb3eQehyBNzYjfA==",
       "dev": true
     },
     "node_modules/@octokit/types": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "module",
   "description": "Error class for Octokit request errors",
   "scripts": {
     "build": "node scripts/build.mjs && tsc -p tsconfig.json",
@@ -27,7 +28,7 @@
     "once": "^1.4.0"
   },
   "devDependencies": {
-    "@octokit/tsconfig": "^2.0.0",
+    "@octokit/tsconfig": "^3.0.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@types/once": "^1.4.0",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -43,7 +43,7 @@ async function main() {
       bundle: true,
       platform: "node",
       target: "node18",
-      format: "cjs",
+      format: "esm",
       ...sharedOptions,
     }),
     // Build an ESM browser bundle
@@ -74,10 +74,18 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-        main: "dist-node/index.js",
-        browser: "dist-web/index.js",
-        types: "dist-types/index.d.ts",
-        module: "dist-src/index.js",
+        exports: {
+          ".": {
+            node: {
+              types: "./dist-types/index.d.ts",
+              import: "./dist-node/index.js",
+            },
+            browser: {
+              types: "./dist-types/index.d.ts",
+              import: "./dist-web/index.js",
+            }
+          }
+        },
         sideEffects: false,
         unpkg: "dist-web/index.js",
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,5 @@
-import { Deprecation } from "deprecation";
-import once from "once";
-const logOnceCode = once((deprecation: any) => console.warn(deprecation));
-const logOnceHeaders = once((deprecation: any) => console.warn(deprecation));
-
-import type {
-  RequestOptions,
-  ResponseHeaders,
-  OctokitResponse,
-} from "@octokit/types";
-import type { RequestErrorOptions } from "./types";
+import type { RequestOptions, OctokitResponse } from "@octokit/types";
+import type { RequestErrorOptions } from "./types.js";
 
 /**
  * Error with extra properties to help with debugging
@@ -22,23 +13,9 @@ export class RequestError extends Error {
   status: number;
 
   /**
-   * http status code
-   *
-   * @deprecated `error.code` is deprecated in favor of `error.status`
-   */
-  code!: number;
-
-  /**
    * Request options that lead to the error.
    */
   request: RequestOptions;
-
-  /**
-   * error response headers
-   *
-   * @deprecated `error.headers` is deprecated in favor of `error.response.headers`
-   */
-  headers!: ResponseHeaders;
 
   /**
    * Response object if a response was received
@@ -60,15 +37,9 @@ export class RequestError extends Error {
 
     this.name = "HttpError";
     this.status = statusCode;
-    let headers: ResponseHeaders;
-
-    if ("headers" in options && typeof options.headers !== "undefined") {
-      headers = options.headers;
-    }
 
     if ("response" in options) {
       this.response = options.response;
-      headers = options.response.headers;
     }
 
     // redact request credentials without mutating original request options
@@ -91,27 +62,5 @@ export class RequestError extends Error {
       .replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
 
     this.request = requestCopy;
-
-    // deprecations
-    Object.defineProperty(this, "code", {
-      get() {
-        logOnceCode(
-          new Deprecation(
-            "[@octokit/request-error] `error.code` is deprecated, use `error.status`.",
-          ),
-        );
-        return statusCode;
-      },
-    });
-    Object.defineProperty(this, "headers", {
-      get() {
-        logOnceHeaders(
-          new Deprecation(
-            "[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`.",
-          ),
-        );
-        return headers || {};
-      },
-    });
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: remove `code` and `headers` properties that were previously deprecated
BREAKING CHANGE: switch package to ESM instead of CommonJS