### PR TITLE
fix(build): remove NodeJS/Browser specific builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -33,30 +33,6 @@ async function main() {
     await rm(typeFile);
   }
 
-  const entryPoints = ["./pkg/dist-src/index.js"];
-
-  await Promise.all([
-    // Build the a CJS Node.js bundle
-    esbuild.build({
-      entryPoints,
-      outdir: "pkg/dist-node",
-      bundle: true,
-      platform: "node",
-      target: "node18",
-      format: "esm",
-      ...sharedOptions,
-    }),
-    // Build an ESM browser bundle
-    esbuild.build({
-      entryPoints,
-      outdir: "pkg/dist-web",
-      bundle: true,
-      platform: "browser",
-      format: "esm",
-      ...sharedOptions,
-    }),
-  ]);
-
   // Copy the README, LICENSE to the pkg folder
   await copyFile("LICENSE", "pkg/LICENSE");
   await copyFile("README.md", "pkg/README.md");
@@ -76,18 +52,12 @@ async function main() {
         files: ["dist-*/**", "bin/**"],
         exports: {
           ".": {
-            node: {
-              types: "./dist-types/index.d.ts",
-              import: "./dist-node/index.js",
-            },
-            browser: {
-              types: "./dist-types/index.d.ts",
-              import: "./dist-web/index.js",
-            }
+            types: "./dist-types/index.d.ts",
+            import: "./dist-src/index.js",
           }
         },
         sideEffects: false,
-        unpkg: "dist-web/index.js",
+        unpkg: "dist-src/index.js",
       },
       null,
       2


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Published a NodeJS build, a Browser build and a neutral source transpilation
* Users who have the `moduleResolution` option in their `tsconfig.json` set to `bundler` couldn't consume the package

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Only publishes the neutral source transpilation, as in this case all the builds were the same
* Reduces size of the NPM package
* Users who have the `moduleResolution` option in their `tsconfig.json` set to `bundler` can consume the package

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

