### PR TITLE
fix(pkg): add `default` fallback and `types` export

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ import { RequestError } from "@octokit/request-error";
 </table>
 
 > [!IMPORTANT]
-> As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
+> As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json` by setting `"moduleResolution": "node16", "module": "node16"`.
+>
+> See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).<br>
+> See this [helpful guide on transitioning to ESM](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) from [@sindresorhus](https://github.com/sindresorhus)
 
 ```js
 const error = new RequestError("Oops", 500, {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ import { RequestError } from "@octokit/request-error";
 </tbody>
 </table>
 
+> [!NOTE]
+> As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
+
 ```js
 const error = new RequestError("Oops", 500, {
   request: {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import { RequestError } from "@octokit/request-error";
 </tbody>
 </table>
 
-> [!NOTE]
+> [!IMPORTANT]
 > As we use [conditional exports](https://nodejs.org/api/packages.html#conditional-exports), you will need to adapt your `tsconfig.json`. See the TypeScript docs on [package.json "exports"](https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports).
 
 ```js

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -50,12 +50,13 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
-        main: "./dist-src/index.js",
         types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",
             import: "./dist-src/index.js",
+            // Tooling currently are having issues with the "exports" field when there is no "default", ex: TypeScript, eslint
+            default: "./dist-src/index.js",
           }
         },
         sideEffects: false,


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Resolves octokit/core.js#667 
Resolves octokit/core.js#665
Partly reverts #406

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- Some consumers of this package could not resolve it properly (ex: `jest`, `ts-node`, `tsx`)
- CJS consumers would be getting errors even though the package is ESM
- Consumers cannot import paths from the package like in CJS

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Clients should be able to import the module without any errors with the fallback
- CJS consumers will generate a better error with the new fallback
- Consumers are able to import types from the `dist-types/types.d.ts` file in the package


### Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

---
