### PR TITLE
fix: improve perf

### DIFF
--- a/benchmarks/instantiate.mjs
+++ b/benchmarks/instantiate.mjs
@@ -1,0 +1,73 @@
+import { Bench } from 'tinybench';
+import { RequestError } from "../pkg/dist-src/index.js";
+
+const bench = new Bench({ time: 100 });
+
+const optionsWithSimpleRequest = Object.assign({}, {
+  request: {
+    method: "POST",
+    url: "https://api.github.com/authorizations",
+    headers: {},
+    body: {
+      note: "test",
+    },
+  },
+  response: {
+    headers: {},
+    status: 200,
+    url: "https://api.github.com/",
+    data: {},
+  }
+});
+
+const optionsWithRequestHavingClientSecretInQuery = Object.assign({}, {
+  request: {
+    method: "POST",
+    url: "https://api.github.com/authorizations?client_secret=secret",
+    headers: {},
+    body: {
+      note: "test",
+    },
+  },
+  response: {
+    headers: {},
+    status: 200,
+    url: "https://api.github.com/",
+    data: {},
+  }
+});
+
+const optionsWithRequestHavingAuthorizationHeader = Object.assign({}, {
+  request: {
+    method: "POST",
+    url: "https://api.github.com/authorizations",
+    headers: {
+      authorization: "token secret123",
+    },
+    body: {
+      note: "test",
+    },
+  },
+  response: {
+    headers: {},
+    status: 200,
+    url: "https://api.github.com/",
+    data: {},
+  }
+});
+
+bench
+.add('instantiate a simple RequestError', () => {
+  new RequestError("test", 123, optionsWithSimpleRequest)
+})
+.add('instantiate a RequestError with authorization header in header', () => {
+  new RequestError("test", 123, optionsWithRequestHavingAuthorizationHeader)
+})
+.add('instantiate a RequestError with client_secret in query', () => {
+  new RequestError("test", 123, optionsWithRequestHavingClientSecretInQuery)
+})
+
+await bench.warmup(); // make results more reliable, ref: https://github.com/tinylibs/tinybench/pull/50
+await bench.run();
+
+console.table(bench.table());

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "glob": "^11.0.0",
         "jest": "^29.0.0",
         "prettier": "3.3.2",
+        "tinybench": "^2.8.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
       },
@@ -4604,6 +4605,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.8.0.tgz",
+      "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
+      "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "glob": "^11.0.0",
     "jest": "^29.0.0",
     "prettier": "3.3.2",
+    "tinybench": "^2.8.0",
     "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,12 +29,6 @@ export class RequestError extends Error {
   ) {
     super(message);
 
-    // Maintains proper stack trace (only available on V8)
-    /* istanbul ignore next */
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-
     this.name = "HttpError";
 
     // Implicit coercion to number if statusCode is a string


### PR DESCRIPTION
If an Error is instantiated in nodejs, then the Error is enriched with the stacktrace anyway. I could not figure out, in which case the stacktrace could be wrong. 

We significantly increase the instantiation speed. 

The stacktrace generation is in general the slowest part of the error instantiation. So touching other parts of the code will not change the performance of the error instantiation significantly.  E.g. we could check if the query contains a `?` before doing the `.replace` calls for `client_secret` and `access_token` which should boost the performance, but it has no effect, because of the slow instantiation of Errors in general. 

before:
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/request-error.js$ node ./benchmarks/instantiate.mjs 
┌─────────┬──────────────────────────────────────────────────────────────────┬──────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name                                                        │ ops/sec  │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼──────────────────────────────────────────────────────────────────┼──────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'instantiate a simple RequestError'                              │ '93,794' │ 10661.642643923351 │ '±0.82%' │ 9380    │
│ 1       │ 'instantiate a RequestError with authorization header in header' │ '95,574' │ 10463.005231219588 │ '±0.79%' │ 9558    │
│ 2       │ 'instantiate a RequestError with client_secret in query'         │ '93,176' │ 10732.264971023862 │ '±1.28%' │ 9318    │
└─────────┴──────────────────────────────────────────────────────────────────┴──────────┴────────────────────┴──────────┴─────────┘
```

after: 
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/request-error.js$ node ./benchmarks/instantiate.mjs 
┌─────────┬──────────────────────────────────────────────────────────────────┬───────────┬───────────────────┬──────────┬─────────┐
│ (index) │ Task Name                                                        │ ops/sec   │ Average Time (ns) │ Margin   │ Samples │
├─────────┼──────────────────────────────────────────────────────────────────┼───────────┼───────────────────┼──────────┼─────────┤
│ 0       │ 'instantiate a simple RequestError'                              │ '163,904' │ 6101.095540235711 │ '±1.29%' │ 16391   │
│ 1       │ 'instantiate a RequestError with authorization header in header' │ '158,418' │ 6312.399128897308 │ '±2.85%' │ 15842   │
│ 2       │ 'instantiate a RequestError with client_secret in query'         │ '160,375' │ 6235.384337199317 │ '±1.11%' │ 16038   │
└─────────┴──────────────────────────────────────────────────────────────────┴───────────┴───────────────────┴──────────┴─────────┘
```