### PR TITLE
Add explicit `| undefined` to optional fields to improve compatibility with `exactOptionalPropertyTypes: true`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export class RequestError extends Error {
   /**
    * Response object if a response was received
    */
-  response?: OctokitResponse<unknown>;
+  response?: OctokitResponse<unknown> | undefined;
 
   constructor(
     message: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { RequestOptions, OctokitResponse } from "@octokit/types";
 
 export type RequestErrorOptions = {
-  response?: OctokitResponse<unknown>;
+  response?: OctokitResponse<unknown> | undefined;
   request: RequestOptions;
 };


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #461

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Typechecking fails in consuming code if undefined is passed to optional properties
* Read more about this ts config here https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Typechecking succeeds

### Pull request checklist
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

