### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,6 @@
 name: "Code scanning - action"
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/octokit/request-error.js/security/code-scanning/11](https://github.com/octokit/request-error.js/security/code-scanning/11)

To fix the problem, we should explicitly add a `permissions` block to the workflow, setting the minimum required permissions for the `GITHUB_TOKEN`. Since the existing jobs primarily perform code scanning and do not appear to need write access (such as creating issues or modifying pull requests), the minimal permission should be `contents: read`. This can be set either at the workflow (root) level (applies to all jobs), or at the job level (applies only to the job). The best approach is to add it at the root, to ensure least privilege for all jobs now and in the future.

Specifically, insert 
```yaml
permissions:
  contents: read
```
after the `name:` field and before the `on:` block in `.github/workflows/codeql.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
